### PR TITLE
[37기 라용] 로그인 디자인 완료 / 소셜로그인 완료

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Login from "pages/Login/Login";
-import SignUp from "pages/SignUp/SignUp";
 import Main from "pages/Main/Main";
 import Recruitment from "pages/Recruitment/Recruitment";
 import Faq from "pages/Faq/Faq";
@@ -10,6 +9,7 @@ import WishList from "pages/WishList/WishList";
 import Mypage from "pages/Mypage/Mypage";
 import Header from "components/Header/Header";
 import Footer from "components/Footer/Footer";
+import OAuth from "pages/Login/SocialLogin/OAuth";
 
 const Router = () => {
   return (
@@ -18,7 +18,7 @@ const Router = () => {
       <Routes>
         <Route path="/" element={<Main />} />
         <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<SignUp />} />
+        <Route path="/user/signin" element={<OAuth />} />
         <Route path="/recruitment" element={<Recruitment />} />
         <Route path="/faq" element={<Faq />} />
         <Route path="/crewrecruit" element={<CrewRecruit />} />

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,7 +1,32 @@
 import React from "react";
+import styled from "styled-components";
+import LoginInput from "./LoginInput";
+import LoginBtn from "./LoginBtn";
+import SocialLogin from "./SocialLogin/SocialLogin";
 
 const Login = () => {
-  return <div>카카오톡 로그인</div>;
+  return (
+    <S.LoginWrap>
+      <S.LoginTitle>로그인</S.LoginTitle>
+      <LoginInput text="이메일을 입력하세요." />
+      <LoginInput text="비밀번호를 입력하세요." />
+      <LoginBtn />
+      <SocialLogin />
+    </S.LoginWrap>
+  );
 };
 
 export default Login;
+
+const S = {
+  LoginWrap: styled.div`
+    width: 400px;
+    margin: 100px auto 100px;
+  `,
+  LoginTitle: styled.p`
+    padding: 30px;
+    font-size: 35px;
+    font-weight: 900;
+    text-align: center;
+  `,
+};

--- a/src/pages/Login/LoginBtn.js
+++ b/src/pages/Login/LoginBtn.js
@@ -1,0 +1,27 @@
+import React from "react";
+import styled from "styled-components";
+
+const LoginBtn = () => {
+  return (
+    <S.BtnWrap>
+      <S.Button>로그인</S.Button>
+    </S.BtnWrap>
+  );
+};
+
+export default LoginBtn;
+
+const S = {
+  BtnWrap: styled.div`
+    padding: 20px 0 30px;
+    border-bottom: 1px solid #aaa;
+  `,
+  Button: styled.button`
+    width: 100%;
+    padding: 20px 20px;
+    color: white;
+    background: #555;
+    border: none;
+    cursor: pointer;
+  `,
+};

--- a/src/pages/Login/LoginInput.js
+++ b/src/pages/Login/LoginInput.js
@@ -1,0 +1,17 @@
+import React from "react";
+import styled from "styled-components";
+
+const LoginInput = ({ text }) => {
+  return <S.InputBox placeholder={text} />;
+};
+
+export default LoginInput;
+
+const S = {
+  InputBox: styled.input`
+    width: 100%;
+    padding: 15px 20px;
+    margin-bottom: 10px;
+    outline: none;
+  `,
+};

--- a/src/pages/Login/SocialLogin/OAuth.js
+++ b/src/pages/Login/SocialLogin/OAuth.js
@@ -1,0 +1,48 @@
+import React, { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import variables from "styles/variables";
+
+const OAuth = () => {
+  const navigate = useNavigate();
+  const code = new URL(window.location.href).searchParams.get("code");
+
+  useEffect(() => {
+    fetch(`http://172.20.10.3:3000/user/signin?code=${code}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;",
+      },
+    })
+      .then((response) => {
+        if (response.ok) return response.json();
+        throw new Error("에러 발생!");
+      })
+      .catch((error) => alert(error))
+      .then((data) => {
+        if (data.result) {
+          localStorage.setItem("TOKEN", data.result);
+          alert("로그인 성공");
+          navigate("/");
+          window.location.reload();
+        } else {
+          alert("로그인 실패");
+        }
+      });
+  }, []);
+
+  return <S.Box>조금만 기다려주세요!</S.Box>;
+};
+
+export default OAuth;
+
+const S = {
+  Box: styled.div`
+    ${variables.flexSet()}
+    height: 600px;
+    font-size: 30px;
+    font-weight: 900;
+    color: #999;
+    background: #efefef;
+  `,
+};

--- a/src/pages/Login/SocialLogin/SocialLogin.js
+++ b/src/pages/Login/SocialLogin/SocialLogin.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { SiNaver } from "react-icons/si";
+import styled from "styled-components";
+import variables from "styles/variables";
+
+const SocialLogin = () => {
+  const NAVER_AUTH_URI = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.REACT_APP_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_REDIRECT_URI}&state=cosegu`;
+
+  const loginHandler = () => {
+    window.location.href = NAVER_AUTH_URI;
+  };
+
+  return (
+    <S.BtnWrap>
+      <S.Button onClick={loginHandler}>
+        <SiNaver size="18px" className="icon" />
+        네이버로 로그인 하기
+      </S.Button>
+    </S.BtnWrap>
+  );
+};
+
+export default SocialLogin;
+
+const S = {
+  BtnWrap: styled.div`
+    padding: 30px 0;
+  `,
+  Button: styled.button`
+    ${variables.flexSet("center", "center")};
+    width: 100%;
+    padding: 15px 20px;
+    font-weight: 900;
+    color: white;
+    background: #04cf5c;
+    border: none;
+    cursor: pointer;
+    .icon {
+      margin-right: 10px;
+    }
+  `,
+};

--- a/src/pages/SignUp/SignUp.js
+++ b/src/pages/SignUp/SignUp.js
@@ -1,7 +1,0 @@
-import React from "react";
-
-const SignUp = () => {
-  return <div>SignUp</div>;
-};
-
-export default SignUp;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 스타일 컴포넌트 활용 로그인 레이아웃 작업
- 네이버 소셜 로그인 기능 적용

<br />

## :: 구현 사항 설명 
- 기존 사이트 회원가입, 로그인은 사용하지 않지만, 기본적인 형태는 잡은 상태입니다. 
- 네이버 소셜 로그인 api 에 접속해 인가 코드를 받고 백엔드에 넘겨준 후, 백엔드에서 생성한 토큰을 발급받았습니다. 백엔드에서는 보내준 인가코드로 토큰을 발급받아 유저의 정보를 받는 것까지 확인 했습니다.

<br />

## :: 성장 포인트
- 처음에 카카오 로그인을 하다 받을 수 있는 정보가 제한적이라 네이버 로그인으로 변경했습니다. 그 과정에서 두가지 소셜로그인 공식문서를 살펴볼 수 있었습니다. 아직은 공식 문서보다 블로그글이 편하지만 공식문서에 접근하고 찾아보는 연습을 어느 정도 했습니다. 
- api 를 쓰는 원리를 어느 정도 이해했습니다. (특정 정보를 담은 url 로 이동 후, 리데이렉트 로 이동 후 url 로 전달받은 정보를 뽑아내서 백엔드에 전달) 
- REST api 키 처럼 보안상 깃허브에 노출되면 안되는 정보는 .env 파일에 환경변수로 관리하고 해당 파일을 gitignore 에 추가해 추적하지 않게 세팅해야 한다는 것을 배웠습니다. 

<br />

## :: 기타 질문 및 특이 사항
- 없습니다!
