### PR TITLE
[37기 라용] Add : 헤더, 찜한 공고 숫자 표시, 목데이터로 기능 구현 완료

### DIFF
--- a/public/data/likelist.json
+++ b/public/data/likelist.json
@@ -1,0 +1,25 @@
+{
+  "likeList": [
+    {
+      "title": "S백화점 차세대 시스템 분석 및 개발",
+      "description": "구분: 경력 \n모집지역: 서울 \n고용형태: 계약직",
+      "main_business": "발주, 물류, 재고 화면 개발",
+      "qualification": "JAVA를 통한 개발이 능숙하신 분\n발주, 물류, 재고와 관련된 지식을 갖추신 분",
+      "preferential_treatment": "해당 업무 분석 및 설계 경험자"
+    },
+    {
+      "title": "S백화점 차세대 시스템 분석 및 개발",
+      "description": "구분: 경력 \n모집지역: 서울 \n고용형태: 계약직",
+      "main_business": "발주, 물류, 재고 화면 개발",
+      "qualification": "JAVA를 통한 개발이 능숙하신 분\n발주, 물류, 재고와 관련된 지식을 갖추신 분",
+      "preferential_treatment": "해당 업무 분석 및 설계 경험자"
+    },
+    {
+      "title": "S백화점 차세대 시스템 분석 및 개발",
+      "description": "구분: 경력 \n모집지역: 서울 \n고용형태: 계약직",
+      "main_business": "발주, 물류, 재고 화면 개발",
+      "qualification": "JAVA를 통한 개발이 능숙하신 분\n발주, 물류, 재고와 관련된 지식을 갖추신 분",
+      "preferential_treatment": "해당 업무 분석 및 설계 경험자"
+    }
+  ]
+}

--- a/src/components/Header/HeaderIcon/LikeIcon.js
+++ b/src/components/Header/HeaderIcon/LikeIcon.js
@@ -1,14 +1,36 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import styled from "styled-components";
 import { AiOutlineHeart } from "react-icons/ai";
+import { API } from "config";
+import styled from "styled-components";
 import variables from "styles/variables";
+import theme from "styles/theme";
 
 const LikeIcon = () => {
+  const [likeCount, setLikeCount] = useState(0);
+
+  useEffect(() => {
+    fetch("/data/likelist.json")
+      .then((res) => res.json())
+      .then((res) => setLikeCount(res.likeList.length));
+  }, []);
+
+  // 백엔드 통신은 아래 코드로
+  // useEffect(() => {
+  //   fetch(`${API}/내용추가`, {
+  //     headers: {
+  //       authorization: localStorage.getItem("TOKEN"),
+  //       "Content-Type": "application/json;charset=utf-8",
+  //     },
+  //   })
+  //     .then((res) => res.json())
+  //     .then((res) => setLikeCount(res.likeList.length));
+  // }, []);
+
   return (
     <LinkIcon to="/wishlist">
       <AiOutlineHeart size="28px" className="icon" />
-      <LikeCount>3</LikeCount>
+      {Boolean(likeCount) && <LikeCount>{likeCount}</LikeCount>}
     </LinkIcon>
   );
 };
@@ -28,6 +50,6 @@ const LikeCount = styled.div`
   height: 20px;
   padding-top: 2px;
   color: white;
-  background: ${(props) => props.theme.mainColor};
+  background: ${theme.mainColor};
   border-radius: 50%;
 `;

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,10 +1,16 @@
 import React from "react";
+import { useEffect } from "react";
 import styled from "styled-components";
 import LoginInput from "./LoginInput";
 import LoginBtn from "./LoginBtn";
 import SocialLogin from "./SocialLogin/SocialLogin";
 
 const Login = () => {
+  // 임시 토큰 생성, 로그인 이후 고려
+  useEffect(() => {
+    window.localStorage.setItem("TOKEN", 20);
+  }, []);
+
   return (
     <S.LoginWrap>
       <S.LoginTitle>로그인</S.LoginTitle>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 찜한 목록 데이터를 불러와 헤더에 표시

<br />

## :: 구현 사항 설명 
- 배열에 담긴 찜한 공고 갯수를 가져와서 표시 (실제 명세에 따른 목데이터 활용)

<br />

## :: 기타 질문 및 특이 사항
- api 명세에 맞는 목데이터 활용해서 카운트가 표시되도록 수정했습니다.
- 주석 처리한 부분은 이후 백엔드 통신시 사용할 코드라서 남겨두었습니다.
